### PR TITLE
Change haproxy-1.5-dev22 source location.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,3 +47,16 @@ default['rs-haproxy']['health_check_uri'] = '/'
 # Algorithm used by load balancer to direct traffic
 # Supported algorithms - "roundrobin", "leastconn", "source"
 default['rs-haproxy']['balance_algorithm'] = 'roundrobin'
+
+# HAProxy install method
+# Supported values - 'package', 'source'
+default['rs-haproxy']['install_method'] = 'source'
+
+# HAProxy source version
+default['rs-haproxy']['source']['version'] = '1.5-dev22'
+
+# HAProxy source URL
+default['rs-haproxy']['source']['url'] = 'https://servertemplate-software-sources.s3.amazonaws.com/haproxy-1.5-dev22.tar.gz'
+
+# HAProxy source SHA256 checksum
+default['rs-haproxy']['source']['checksum'] = 'b0978b4802a48ee60ca79c01c0b020c5155ac8248af65d24a248ace91b87ac2e'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,18 +21,20 @@ marker "recipe_start_rightscale" do
   template "rightscale_audit_entry.erb"
 end
 
+# If installing from source, update attributes accordingly.
+if node['rs-haproxy']['install_method'] == 'source'
+  Chef::Log.info "Overriding haproxy/install_method to 'source'..."
+  node.override['haproxy']['install_method'] = node['rs-haproxy']['install_method']
+
+  Chef::Log.info "Overriding haproxy/source/version to #{node['rs-haproxy']['source']['version']}"
+  node.override['haproxy']['source']['version'] = node['rs-haproxy']['source']['version']
+
+  Chef::Log.info "Overriding haproxy/source/url to #{node['rs-haproxy']['source']['url']}"
+  node.override['haproxy']['source']['url'] = node['rs-haproxy']['source']['url']
+  node.override['haproxy']['source']['checksum'] = node['rs-haproxy']['source']['checksum']
+end
+
 # Override haproxy cookbook attributes
-Chef::Log.info "Overriding haproxy/install_method to 'source'..."
-node.override['haproxy']['install_method'] = 'source'
-
-Chef::Log.info "Overriding haproxy/source/version to '1.5-dev22'..."
-node.override['haproxy']['source']['version'] = '1.5-dev22'
-
-source_url = 'https://servertemplate-software-sources.s3.amazonaws.com/haproxy-1.5-dev22.tar.gz'
-Chef::Log.info "Overriding haproxy/source/url to '#{source_url}'"
-node.override['haproxy']['source']['url'] = source_url
-node.override['haproxy']['source']['checksum'] = 'b0978b4802a48ee60ca79c01c0b020c5155ac8248af65d24a248ace91b87ac2e'
-
 Chef::Log.info "Overriding haproxy/source/use_openssl to 'true'"
 node.override['haproxy']['source']['use_openssl'] = true
 


### PR DESCRIPTION
Use a different location for haproxy-1.5-dev22.tar.gz instead of official website, known to have downloading issues when new versions of haproxy are published.
